### PR TITLE
Revert "[GG-7338] removed empty <option> causing a11y test failures"

### DIFF
--- a/app/views/fragments/EntryForm.scala.html
+++ b/app/views/fragments/EntryForm.scala.html
@@ -61,7 +61,7 @@
     @govukSelect(Select(
         id = "addedByTeam",
         name = "addedByTeam",
-        items = siProtectedUserConfig.addedByTeams.map(team => SelectItem(Some(team), team)),
+        items = Seq(SelectItem(None, "")) ++ siProtectedUserConfig.addedByTeams.map(team => SelectItem(Some(team), team)),
         label = Label(content = Text(messages("entry.form.addedByTeam")), classes = "govuk-!-font-weight-bold")
     ).withFormField(form("addedByTeam")))
     @govukButton(Button(content = Text(Messages(submitButtonMessageKey))))


### PR DESCRIPTION
Reverts hmrc/si-protected-user-list-admin-frontend#29